### PR TITLE
Fixed sass line height calc bug same as commit 3bf4a8e1

### DIFF
--- a/_objects.buttons.scss
+++ b/_objects.buttons.scss
@@ -312,7 +312,7 @@ button.#{$inuit-btn-namespace}btn {
   %#{$inuit-btn-namespace}btn--small {
       height: $inuit-btn-height--small;
       font-size: calculateRem(12px);
-      line-height: calc($inuit-btn-height--small - 2px);
+      line-height: calc(#{$inuit-btn-height--small} - 2px);
   }
 
   /** Workaround for FF since it does not support calc().


### PR DESCRIPTION
There's another spot where this is needed.

https://github.com/PredixDev/px-buttons-design/commit/3bf4a8e1c8bc80985a6ea319c69370c0b0574015
