### PR TITLE
updating styles for bare buttons

### DIFF
--- a/_objects.buttons.scss
+++ b/_objects.buttons.scss
@@ -110,6 +110,9 @@ $inuit-enable-btn--icon                             : false !default;
 /// @type Boolean [default] - Produce CSS for bare buttons?
 $inuit-enable-btn--bare                             : false !default;
 
+/// @type Boolean [default] - Produce CSS for bare--primary buttons?
+$inuit-enable-btn--bare--primary                    : false !default;
+
 /// @type Boolean [default] - Produce CSS for disabled buttons?
 $inuit-enable-btn--disabled                         : false !default;
 
@@ -196,6 +199,13 @@ button.#{$inuit-btn-namespace}btn {
     border-radius: 0;
     padding: 0;
     line-height: inherit;
+    font-size: calculateRem(18px);
+    width: calculateRem(34px);
+    height: calculateRem(34px);
+    box-shadow: none;
+    background: none;
+    outline:none;
+
     &,
     &:link,
     &:visited,
@@ -204,12 +214,73 @@ button.#{$inuit-btn-namespace}btn {
     &:focus {
       box-shadow: none;
       background: none;
-      color: inherit;
+      outline:none;
     }
+
+    &,
+    &:link,
+    &:visited {
+      color: $gray8;
+    }
+
+    &:hover {
+      color: $primary-blue;
+    }
+
+    &:active,
+    &:focus {
+      color: $primary-blue-pressed;
+    }
+
   }
 
 }
 
+@if ($inuit-enable-btn--bare--primary == true) {
+
+.#{$inuit-btn-namespace}btn--bare--primary,
+%#{$inuit-btn-namespace}btn--bare--primary {
+    height: auto;
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    line-height: inherit;
+    font-size: calculateRem(18px);
+    width: calculateRem(34px);
+    height: calculateRem(34px);
+    box-shadow: none;
+    background: none;
+    outline:none;
+
+    &,
+    &:link,
+    &:visited,
+    &:hover,
+    &:active,
+    &:focus {
+      box-shadow: none;
+      background: none;
+      outline:none;
+    }
+
+    &,
+    &:link,
+    &:visited {
+      color: $primary-blue;
+    }
+
+    &:hover {
+      color: $primary-blue-hover;
+    }
+
+    &:active,
+    &:focus {
+      color: $primary-blue-pressed;
+    }
+
+  }
+
+}
 
 
 @if ($inuit-enable-btn--primary == true) {

--- a/src/index.html
+++ b/src/index.html
@@ -329,6 +329,42 @@
         </button>
       </div>
 
+      <h3>Sass Flag</h3>
+      <figure class="code">
+        <code>
+          $inuit-enable-btn--bare--primary : true;
+        </code>
+      </figure>
+      <small>
+        Flag must be set before
+        <code class="code code--inline">@import</code>
+        in component Sass file.
+      </small>
+      <h3>HTML</h3>
+      <figure class="code u-mb+">
+        <code>
+          &lt;button class="btn btn--bare--primary"&gt;
+          <br>
+          &nbsp;&nbsp;&lt;i class="fa fa-&hellip;"&gt;&lt;/i&gt;
+          <br>
+          &lt;/button&gt;
+        </code>
+      </figure>
+      <div class=u-mb+>
+        <button class="btn btn--bare--primary u-mr u-mb+" type=button>
+          <i class="fa fa-gear"></i>
+        </button>
+        <button class="btn btn--bare--primary u-mr u-mb+" type=button>
+          <i class="fa fa-refresh"></i>
+        </button>
+        <button class="btn btn--bare--primary u-mr u-mb+" type=button>
+          <i class="fa fa-arrows"></i>
+        </button>
+        <button class="btn btn--bare--primary u-mr u-mb+" type=button>
+          <i class="fa fa-external-link"></i>
+        </button>
+      </div>
+
       <h2>Support for non-button elements</h2>
       <figure class="code u-mv+">
         <code>

--- a/src/style.scss
+++ b/src/style.scss
@@ -21,6 +21,7 @@ $inuit-enable-btn--full         : true;
 $inuit-enable-btn--icon         : true;
 
 $inuit-enable-btn--bare         : true;
+$inuit-enable-btn--bare--primary : true;
 $inuit-enable-btn--primary      : true;
 $inuit-enable-btn--tertiary     : true;
 $inuit-enable-btn--disabled     : true;


### PR DESCRIPTION
- Updated btn--bare styles to improve hit target, and added hover/selected states
![screen shot 2016-07-07 at 5 42 04 pm](https://cloud.githubusercontent.com/assets/6137443/16674361/38e385a2-446c-11e6-8401-cb211651eda7.png)


![screen shot 2016-07-07 at 5 42 25 pm](https://cloud.githubusercontent.com/assets/6137443/16674324/c359015e-446b-11e6-81c9-2df30c27a381.png)

- Added a btn--bare--primary modifier for alternative button colors and hover/selected states ($primary-blue, $primary-blue-hover, $primary-blue-selected )

- updated demo index.html
- updated style.scss to enable modifier

Let me know if the modifier makes sense, or if you suggest a different approach.

